### PR TITLE
Change recaptcha variable from private to public

### DIFF
--- a/src/ReCaptchaInstance.ts
+++ b/src/ReCaptchaInstance.ts
@@ -7,7 +7,7 @@ import { IReCaptchaInstance } from './grecaptcha/grecaptcha'
  */
 export class ReCaptchaInstance {
   private readonly siteKey: string
-  private readonly recaptcha: IReCaptchaInstance
+  public readonly recaptcha: IReCaptchaInstance
   private styleContainer: HTMLStyleElement
 
   public constructor (siteKey: string, recaptcha: IReCaptchaInstance) {


### PR DESCRIPTION
**Why?**
I want to reuse instance of grecaptcha to rerender an inline badge replace for current 'bottomright' option only. It same as below.

```
load(siteKey, { autoHideBadge: true }).then(instance => {
  instance.recaptcha.render('badge-wrapper-id', {
    sitekey: SITE_KEY,
    badge: 'inline',
    size: 'invisible',
  });
});
```

**What did i do?**
Modify private variable to public to reuse instance of `grecaptcha` at callback from promise on load.