### PR TITLE
fix(loader): update hide badge style to comply with Google recommendation

### DIFF
--- a/src/ReCaptchaInstance.ts
+++ b/src/ReCaptchaInstance.ts
@@ -48,7 +48,7 @@ export class ReCaptchaInstance {
     }
 
     this.styleContainer = document.createElement('style')
-    this.styleContainer.innerHTML = '.grecaptcha-badge{display:none !important;}'
+    this.styleContainer.innerHTML = '.grecaptcha-badge{visibility:hidden !important;}'
     document.head.appendChild(this.styleContainer)
   }
 


### PR DESCRIPTION
Update the style applied to the reCAPTCHA badge when using the `autoHideBadge` loader option from `display: none` to `visibility: hidden`.

Closes #318