### PR TITLE
feat(enterprise): adds recaptcha enterprise support!

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,25 @@ To use this package you only need a valid site key for your domain, which you ca
 With promises:
 
 ```javascript
-import { load } from 'recaptcha-v3'
+import { load } from "recaptcha-v3";
 
-load('<site key>').then((recaptcha) => {
-  recaptcha.execute('<action>').then((token) => {
-      console.log(token) // Will print the token
-    })
-})
+load("<site key>").then((recaptcha) => {
+  recaptcha.execute("<action>").then((token) => {
+    console.log(token); // Will print the token
+  });
+});
 ```
 
 With async/await:
 
 ```javascript
-import { load } from 'recaptcha-v3'
+import { load } from "recaptcha-v3";
 
 async function asyncFunction() {
-  const recaptcha = await load('<site key>')
-  const token = await recaptcha.execute('<action>')
+  const recaptcha = await load("<site key>");
+  const token = await recaptcha.execute("<action>");
 
-  console.log(token) // Will also print the token
+  console.log(token); // Will also print the token
 }
 ```
 
@@ -59,6 +59,7 @@ Therefore the loader offers optional options for additional configuration:
 | Name                         | Description                                                                                                                                                                                                                                                            | Type      | Default value |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- | ------------- |
 | **useRecaptchaNet**          | Due to limitations in certain countries it's required to use `recaptcha.net` instead of `google.com`.                                                                                                                                                                  | _boolean_ | `false`       |
+| **useEnterprise**            | Uses the enterprise version of the recaptcha api and handles the differences in the response.                                                                                                                                                                          | _boolean_ | `false`       |
 | **autoHideBadge**            | Will automatically hide the reCAPTCHA badge. Warning: The usage is only allowed if you follow the offical guide for hiding the badge from Google ([see here](https://developers.google.com/recaptcha/docs/faq#id-like-to-hide-the-recaptcha-v3-badge-what-is-allowed)) | _boolean_ | `false`       |
 | **renderParameters**         | Will add the given parameters to the reCAPTCHA script. The given object will be converted into a query string and will then be added to the URL.                                                                                                                       | Object    | `{}`          |
 | **explicitRenderParameters** | Will set the parameters to the explicit rendering. [See here](#explicit-render-parameters)                                                                                                                                                                             | Object    | `{}`          |
@@ -69,28 +70,27 @@ To use the options just pass an additional object to the `load(...)` method.
 For example:
 
 ```javascript
-import { load } from 'recaptcha-v3'
+import { load } from "recaptcha-v3";
 
-load('<site key>', {
+load("<site key>", {
   useRecaptchaNet: true,
-  autoHideBadge: true
-}).then((recaptcha) => {
+  autoHideBadge: true,
+}).then((recaptcha) => {});
+```
 
-})
-``` 
 ### Explicit render parameters
+
 The ReCaptcha widget will be explicity loaded, which means you can add parameters to the rendering process.
 
-| Name | Description | Type |
-| ---- | ----------- | ---- |
-| **container** | The container if you want to render the inline widget | `string` or `Element` |
-| **badge** | The positioning for the widget | `'bottomright'` or `'bottomleft'` or `'inline'` |
-| **size** | The size of the widget | `'invisible'` |
-| **tabindex** | The tab index of the widget | `number` | 
-
+| Name          | Description                                           | Type                                            |
+| ------------- | ----------------------------------------------------- | ----------------------------------------------- |
+| **container** | The container if you want to render the inline widget | `string` or `Element`                           |
+| **badge**     | The positioning for the widget                        | `'bottomright'` or `'bottomleft'` or `'inline'` |
+| **size**      | The size of the widget                                | `'invisible'`                                   |
+| **tabindex**  | The tab index of the widget                           | `number`                                        |
 
 ## Wrapper libraries
 
 Wrapper libraries are available for:
 
--   Vue.js plugin ([vue-recaptcha-v3](https://github.com/AurityLab/vue-recaptcha-v3) / [npm](https://www.npmjs.com/package/vue-recaptcha-v3))
+- Vue.js plugin ([vue-recaptcha-v3](https://github.com/AurityLab/vue-recaptcha-v3) / [npm](https://www.npmjs.com/package/vue-recaptcha-v3))

--- a/README.md
+++ b/README.md
@@ -29,25 +29,25 @@ To use this package you only need a valid site key for your domain, which you ca
 With promises:
 
 ```javascript
-import { load } from "recaptcha-v3";
+import { load } from 'recaptcha-v3'
 
-load("<site key>").then((recaptcha) => {
-  recaptcha.execute("<action>").then((token) => {
-    console.log(token); // Will print the token
-  });
-});
+load('<site key>').then((recaptcha) => {
+  recaptcha.execute('<action>').then((token) => {
+      console.log(token) // Will print the token
+    })
+})
 ```
 
 With async/await:
 
 ```javascript
-import { load } from "recaptcha-v3";
+import { load } from 'recaptcha-v3'
 
 async function asyncFunction() {
-  const recaptcha = await load("<site key>");
-  const token = await recaptcha.execute("<action>");
+  const recaptcha = await load('<site key>')
+  const token = await recaptcha.execute('<action>')
 
-  console.log(token); // Will also print the token
+  console.log(token) // Will also print the token
 }
 ```
 
@@ -70,27 +70,28 @@ To use the options just pass an additional object to the `load(...)` method.
 For example:
 
 ```javascript
-import { load } from "recaptcha-v3";
+import { load } from 'recaptcha-v3'
 
-load("<site key>", {
+load('<site key>', {
   useRecaptchaNet: true,
-  autoHideBadge: true,
-}).then((recaptcha) => {});
-```
+  autoHideBadge: true
+}).then((recaptcha) => {
 
+})
+``` 
 ### Explicit render parameters
-
 The ReCaptcha widget will be explicity loaded, which means you can add parameters to the rendering process.
 
-| Name          | Description                                           | Type                                            |
-| ------------- | ----------------------------------------------------- | ----------------------------------------------- |
-| **container** | The container if you want to render the inline widget | `string` or `Element`                           |
-| **badge**     | The positioning for the widget                        | `'bottomright'` or `'bottomleft'` or `'inline'` |
-| **size**      | The size of the widget                                | `'invisible'`                                   |
-| **tabindex**  | The tab index of the widget                           | `number`                                        |
+| Name | Description | Type |
+| ---- | ----------- | ---- |
+| **container** | The container if you want to render the inline widget | `string` or `Element` |
+| **badge** | The positioning for the widget | `'bottomright'` or `'bottomleft'` or `'inline'` |
+| **size** | The size of the widget | `'invisible'` |
+| **tabindex** | The tab index of the widget | `number` | 
+
 
 ## Wrapper libraries
 
 Wrapper libraries are available for:
 
-- Vue.js plugin ([vue-recaptcha-v3](https://github.com/AurityLab/vue-recaptcha-v3) / [npm](https://www.npmjs.com/package/vue-recaptcha-v3))
+-   Vue.js plugin ([vue-recaptcha-v3](https://github.com/AurityLab/vue-recaptcha-v3) / [npm](https://www.npmjs.com/package/vue-recaptcha-v3))

--- a/src/ReCaptchaInstance.ts
+++ b/src/ReCaptchaInstance.ts
@@ -24,7 +24,7 @@ export class ReCaptchaInstance {
    * @param action The action to execute with.
    */
   public async execute(action?: string): Promise<string> {
-    return this.recaptcha.execute(this.recaptchaID, {action})
+    return this.recaptcha.enterprise ? this.recaptcha.enterprise.execute(this.recaptchaID, {action}) :  this.recaptcha.execute(this.recaptchaID, {action})
   }
 
   /**

--- a/src/grecaptcha/grecaptcha.ts
+++ b/src/grecaptcha/grecaptcha.ts
@@ -33,6 +33,8 @@ export interface IReCaptchaInstance {
    * @param parameters The rendering parameters for the widget.
    */
   render(parameters: IRenderParameters): string;
+
+  enterprise: Omit<IReCaptchaInstance,'enterprise'>
 }
 
 /**


### PR DESCRIPTION
This pull request makes a simple change that adds support to the enterprise version of the reCaptcha API for both `google.com` and `recaptcha.net`. 
All you need to do is pass `useEnterprise: true` to the `load` function as an option and that will make the loader use `https://www.google.com/recaptcha/enterprise.js` api instead of the normal `https://www.google.com/recaptcha/api.js`.

The enterprise version of the APIs also has all of the grecapcha methods wrapped in a key called enterprise for a reason. 

<p align="center">
<img src="https://user-images.githubusercontent.com/34731224/125761559-e852a933-94c4-4475-800e-e9300710b86e.png" width="600" align="center">
</p>

This PR adds checks for when `useEnterprise` is `true`, grecapcha methods should be accessed through the enterprise key as shown in the example below
```javascript
        if (useEnterprise) {
          window.grecaptcha.enterprise.ready(() => {
            callback()
          })
        } else {
          window.grecaptcha.ready(() => {
            callback()
          })
        }
```



